### PR TITLE
Mixin primitives when no definition exists on target class

### DIFF
--- a/Cocktail.js
+++ b/Cocktail.js
@@ -31,6 +31,8 @@
                     klass.prototype[key] = value;
                 } else if (_.isObject(value)) {
                     klass.prototype[key] = _.extend({}, value, klass.prototype[key] || {});
+                } else if (!(key in klass.prototype)) {
+                    klass.prototype[key] = value;
                 }
             });
         });

--- a/spec/spec/CocktailSpec.js
+++ b/spec/spec/CocktailSpec.js
@@ -293,10 +293,20 @@ describe('Cocktail', function() {
             });
         });
 
-        describe('handling non-functional override of non-events property', function() {
-            it('should ignore the non-functional mixin property', function() {
+        describe('handling primitive override of non-events property', function() {
+            describe('when class specifies prop', function() {
+              it('should use the class property', function() {
                 var model = new ModelClass();
                 expect(model.url()).toEqual('/gizmos');
+              });
+            });
+            describe('when class does not specify prop', function() {
+              it('should use the class property', function() {
+                var ModelWithoutUrlRoot = Backbone.Model.extend({
+                  mixins: [D]
+                }), model = new ModelWithoutUrlRoot();
+                expect(model.url()).toEqual('/thingamajigs');
+              });
             });
         });
 


### PR DESCRIPTION
If one defines a mixin such as:

var Mixin = { thisIsAPrimitive: fase }

When mixing this mixin in, the value will not be copied to the prototype. This patch performs said mixin only when the target class contains no definition for the primitive. I could also be convinced that overwriting whatever is in the class is appropriate as well.
