### PR TITLE
Add module entry point to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "author": "Onsi Fakhouri <onsijoe@gmail.com>",
   "license": "MIT",
+  "main": "Cocktail.js",
   "readmeFilename": "README.md",
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
Thanks to #34, Cocktail can be installed via npm. This adds a "main" entry to package.json to allow it to be subsequently require()'d in a node-like environment.
