### PR TITLE
Maintain context when resolving collisions

### DIFF
--- a/Cocktail.js
+++ b/Cocktail.js
@@ -49,7 +49,7 @@
         });
 
         _(collisions).each(function(propertyValues, propertyName) {
-            obj[propertyName] = function() {
+            obj[propertyName] = _.bind(function() {
                 var that = this,
                     args = arguments,
                     returnValue;
@@ -60,7 +60,7 @@
                 });
 
                 return returnValue;
-            };
+            }, obj);
         });
 
         return klass;


### PR DESCRIPTION
Fixes a bug where the function being returned to resolve function collisions wasn't being bound to the "parent" being mixed into. This allowed the mixed in functions to execute in unpredictable contexts.
